### PR TITLE
[#5] Add --local-dataset-type Argument to Specify the Local Dataset Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,22 @@ fmo quantize \
 ```
 The command line arguments means :
 - **`model-name-or-path`**: Hugging Face pretrained model name or directory path of the saved model checkpoint.
-- **`local-dataset-type`**: Type of the local dataset file. Defaults to `inferred`. You can choose from `inferred`, `json`, `csv`, `parquet`, and `arrow`.
 - **`output-dir`**: Directory path to save the quantized checkpoint and related configurations.
 - **`mode`**: Quantization techniques to apply. You can use `fp8`, `int8`, and `awq`.
 - **`pedantic-level`**: Represent to accuracy-latency trade-off. Higher pedantic level ensure a more accurate representaition of the model, but increase the quantization processing time. Defaults to 1.
 - **`device`**: Device to run the quantization process. Defaults to "cuda:0".
 - **`offload`**: When enabled, this option significantly reduces GPU memory usage by offloading model layers onto CPU RAM. Defaults to False.
+- **`dataset-name-or-path`**: Hugging Face dataset name or directory path of the local dataset file. If you use a single file, you can set this option to the path of the file and set `local-dataset-type` to the appropriate type.
+- **`local-dataset-type`**: Type of the local dataset file. Set this only when you use a local dataset file. Defaults to `inferred`. You can choose from `inferred`, `json`, `csv`, `parquet`, and `arrow`.
+- **`dataset-split-name`**: The split of the dataset to use (e.g., "train", "test", "validation"). Defaults to "test".
+- **`dataset-target-column-name`**: The name of the column in your dataset containing the text to be processed. For example:
+  - "article" for CNN/DailyMail dataset
+  - "text" for many standard datasets
+  - "content" for custom datasets
+  Defaults to "article". Note that if you want to apply a chat template, you should preprocess your dataset to have a single field for the formatted text.
+- **`dataset-num-samples`**: Number of samples to use from the dataset for calibration. More samples may improve quantization quality but increase processing time. Defaults to 512.
+- **`dataset-max-length`**: Maximum length (in tokens) for each sample from the dataset. Longer sequences will be truncated. Defaults to 1024.
+- **`dataset-batch-size`**: Number of samples to process simultaneously during calibration. If not specified (None), FMO will automatically determine an optimal batch size based on available GPU memory.
 
 ## Example: Run FP8 quantization with Meta-Llama-3-8B-Instruct
 ```bash

--- a/README.md
+++ b/README.md
@@ -140,11 +140,7 @@ The command line arguments means :
 - **`dataset-name-or-path`**: Hugging Face dataset name or directory path of the local dataset file. If you use a single file, you can set this option to the path of the file and set `local-dataset-type` to the appropriate type.
 - **`local-dataset-type`**: Type of the local dataset file. Set this only when you use a local dataset file. Defaults to `inferred`. You can choose from `inferred`, `json`, `csv`, `parquet`, and `arrow`.
 - **`dataset-split-name`**: The split of the dataset to use (e.g., "train", "test", "validation"). Defaults to "test".
-- **`dataset-target-column-name`**: The name of the column in your dataset containing the text to be processed. For example:
-  - "article" for CNN/DailyMail dataset
-  - "text" for many standard datasets
-  - "content" for custom datasets
-  Defaults to "article". Note that if you want to apply a chat template, you should preprocess your dataset to have a single field for the formatted text.
+- **`dataset-target-column-name`**: The name of the column in your dataset containing the text to be processed (for example: "article" for CNN/DailyMail dataset, "text" for many standard datasets). Defaults to "article". Note that if you want to apply a chat template, you should preprocess your dataset to have a single field for the formatted texts.
 - **`dataset-num-samples`**: Number of samples to use from the dataset for calibration. More samples may improve quantization quality but increase processing time. Defaults to 512.
 - **`dataset-max-length`**: Maximum length (in tokens) for each sample from the dataset. Longer sequences will be truncated. Defaults to 1024.
 - **`dataset-batch-size`**: Number of samples to process simultaneously during calibration. If not specified (None), FMO will automatically determine an optimal batch size based on available GPU memory.

--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ fmo quantize \
 ```
 The command line arguments means :
 - **`model-name-or-path`**: Hugging Face pretrained model name or directory path of the saved model checkpoint.
+- **`local-dataset-type`**: Type of the local dataset file. Defaults to `inferred`. You can choose from `inferred`, `json`, `csv`, `parquet`, and `arrow`.
 - **`output-dir`**: Directory path to save the quantized checkpoint and related configurations.
-- **`mode`**: Quantization techniques to apply. You can use `fp8`, `int8`.
+- **`mode`**: Quantization techniques to apply. You can use `fp8`, `int8`, and `awq`.
 - **`pedantic-level`**: Represent to accuracy-latency trade-off. Higher pedantic level ensure a more accurate representaition of the model, but increase the quantization processing time. Defaults to 1.
 - **`device`**: Device to run the quantization process. Defaults to "cuda:0".
 - **`offload`**: When enabled, this option significantly reduces GPU memory usage by offloading model layers onto CPU RAM. Defaults to False.

--- a/src/fmo/main_test.py
+++ b/src/fmo/main_test.py
@@ -1,0 +1,43 @@
+import pytest
+from typer.testing import CliRunner
+from .main import app, LocalDatasetType, QuantMode
+
+runner = CliRunner()
+
+class TestLocalDatasetType:
+    @pytest.mark.parametrize("concrete_type", [
+        (LocalDatasetType.JSON, "json"),
+        (LocalDatasetType.CSV, "csv"),
+        (LocalDatasetType.PARQUET, "parquet"),
+        (LocalDatasetType.ARROW, "arrow"),
+    ])
+    def test_concrete_to_string(self, concrete_type):
+        dataset_type, expected_type = concrete_type
+        assert dataset_type.to_string("any_path") == expected_type
+        
+    @pytest.mark.parametrize("valid_extension", [
+        ("test.json", "json"),
+        ("data.csv", "csv"),
+        ("/some/path/data.parquet", "parquet"),
+        ("random/path/data.arrow", "arrow"),
+    ])
+    def test_valid_extensions(self, valid_extension):
+        path, expected_type = valid_extension
+        assert LocalDatasetType.INFERRED.to_string(path) == expected_type
+
+    @pytest.mark.parametrize("invalid_extension", [
+        "",
+        "test.txt",
+        "data.pdf",
+        "model.bin",
+        "invalid_path",
+    ])
+    def test_invalid_extensions(self, invalid_extension):
+        with pytest.raises(ValueError, match="Unsupported dataset file extension"):
+            LocalDatasetType.INFERRED.to_string(invalid_extension)
+
+class TestCli:
+    def test_version(self):
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == 0
+        assert result.stdout.strip()  # Should contain version string

--- a/src/fmo/utils/dataset.py
+++ b/src/fmo/utils/dataset.py
@@ -20,6 +20,7 @@ logger = get_logger(__name__)
 
 def safe_load_datasets(
     dataset_name_or_path: str,
+    local_dataset_type: str,
     split_name: Optional[str] = None,
     cache_dir: Optional[str] = None,
 ) -> datasets.Dataset:
@@ -27,6 +28,7 @@ def safe_load_datasets(
     try:
         if os.path.exists(dataset_name_or_path):
             dataset = datasets.load_dataset(
+                local_dataset_type,
                 data_files=dataset_name_or_path,
                 split=split_name,
             )


### PR DESCRIPTION
The load_dataset() function requires the path argument as its first positional parameter. This argument is used to specify the dataset type when loading a local file.